### PR TITLE
メインページの新規作成をクリックしたら本文にフォーカスできるようにした＆削除ボタンの実装

### DIFF
--- a/src/components/augs/MainPage/AlertDialog.tsx
+++ b/src/components/augs/MainPage/AlertDialog.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+import Button from "@mui/material/Button";
+import Dialog from "@mui/material/Dialog";
+import DialogActions from "@mui/material/DialogActions";
+import DialogContent from "@mui/material/DialogContent";
+import DialogContentText from "@mui/material/DialogContentText";
+import DialogTitle from "@mui/material/DialogTitle";
+
+type AlertDialogprops = {
+	handleClose: () => void;
+	open: boolean;
+	handleExitWithoutSavingClick: () => void;
+};
+
+export const AlertDialog: React.FC<AlertDialogprops> = ({ handleClose, open, handleExitWithoutSavingClick }) => {
+	// const [open, setOpen] = React.useState(false);
+
+	// const handleClickOpen = () => {
+	// 	setOpen(true);
+	// };
+
+	// const handleClose = () => {
+	// 	setOpen(false);
+	// };
+
+	return (
+		<React.Fragment>
+			<Dialog
+				open={open}
+				onClose={handleClose}
+				aria-labelledby="alert-dialog-title"
+				aria-describedby="alert-dialog-description"
+			>
+				<DialogTitle id="alert-dialog-title">{"編集中の内容を保存しますか"}</DialogTitle>
+				<DialogContent>
+					<DialogContentText id="alert-dialog-description">
+						保存せずに移動した場合、編集中の内容は削除されてしまいます。
+					</DialogContentText>
+				</DialogContent>
+				<DialogActions>
+					<Button onClick={handleClose}>保存</Button>
+					<Button
+						onClick={() => {
+							handleExitWithoutSavingClick();
+							handleClose();
+						}}
+					>
+						保存せずに編集終了
+					</Button>
+					<Button onClick={handleClose} autoFocus>
+						キャンセル
+					</Button>
+				</DialogActions>
+			</Dialog>
+		</React.Fragment>
+	);
+};

--- a/src/components/augs/MainPage/AlertDialog.tsx
+++ b/src/components/augs/MainPage/AlertDialog.tsx
@@ -14,7 +14,7 @@ type AlertDialogprops = {
 
 export const AlertDialog: React.FC<AlertDialogprops> = ({ handleClose, open, handleExitWithoutSavingClick }) => {
 	return (
-		<React.Fragment>
+		<>
 			<Dialog
 				open={open}
 				onClose={handleClose}
@@ -42,6 +42,6 @@ export const AlertDialog: React.FC<AlertDialogprops> = ({ handleClose, open, han
 					</Button>
 				</DialogActions>
 			</Dialog>
-		</React.Fragment>
+		</>
 	);
 };

--- a/src/components/augs/MainPage/DeleteDialog.tsx
+++ b/src/components/augs/MainPage/DeleteDialog.tsx
@@ -37,7 +37,7 @@ export const DeleteDialog: React.FC<DeleteDialogprops> = ({
 		handleClose();
 	};
 	return (
-		<React.Fragment>
+		<>
 			<Dialog
 				open={open}
 				onClose={handleClose}
@@ -57,6 +57,6 @@ export const DeleteDialog: React.FC<DeleteDialogprops> = ({
 					</Button>
 				</DialogActions>
 			</Dialog>
-		</React.Fragment>
+		</>
 	);
 };

--- a/src/components/augs/MainPage/DeleteDialog.tsx
+++ b/src/components/augs/MainPage/DeleteDialog.tsx
@@ -5,13 +5,37 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
+import { TrashMemoMutationVariables } from "@/types";
 
 type DeleteDialogprops = {
 	handleClose: () => void;
 	open: boolean;
+	handlePutTrashMemo: (putBody: TrashMemoMutationVariables) => void;
+	id: number;
+	title: string;
+	content: string;
 };
 
-export const DeleteDialog: React.FC<DeleteDialogprops> = ({ handleClose, open }) => {
+export const DeleteDialog: React.FC<DeleteDialogprops> = ({
+	handleClose,
+	open,
+	handlePutTrashMemo,
+	id,
+	title,
+	content
+}) => {
+	const putBody: TrashMemoMutationVariables = {
+		id,
+		putDate: {
+			title: title,
+			content: content,
+			complete_flag: true
+		}
+	};
+	const handleDeleteButtonClick = () => {
+		handlePutTrashMemo(putBody);
+		handleClose();
+	};
 	return (
 		<React.Fragment>
 			<Dialog
@@ -27,7 +51,7 @@ export const DeleteDialog: React.FC<DeleteDialogprops> = ({ handleClose, open })
 					</DialogContentText>
 				</DialogContent>
 				<DialogActions>
-					<Button onClick={handleClose}>削除</Button>
+					<Button onClick={handleDeleteButtonClick}>削除</Button>
 					<Button onClick={handleClose} autoFocus>
 						キャンセル
 					</Button>

--- a/src/components/augs/MainPage/DeleteDialog.tsx
+++ b/src/components/augs/MainPage/DeleteDialog.tsx
@@ -6,13 +6,12 @@ import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
 
-type AlertDialogprops = {
+type DeleteDialogprops = {
 	handleClose: () => void;
 	open: boolean;
-	handleExitWithoutSavingClick: () => void;
 };
 
-export const AlertDialog: React.FC<AlertDialogprops> = ({ handleClose, open, handleExitWithoutSavingClick }) => {
+export const DeleteDialog: React.FC<DeleteDialogprops> = ({ handleClose, open }) => {
 	return (
 		<React.Fragment>
 			<Dialog
@@ -21,22 +20,14 @@ export const AlertDialog: React.FC<AlertDialogprops> = ({ handleClose, open, han
 				aria-labelledby="alert-dialog-title"
 				aria-describedby="alert-dialog-description"
 			>
-				<DialogTitle id="alert-dialog-title">{"編集中の内容を保存しますか"}</DialogTitle>
+				<DialogTitle id="alert-dialog-title">{"選択中のメモを削除します"}</DialogTitle>
 				<DialogContent>
 					<DialogContentText id="alert-dialog-description">
-						保存せずに移動した場合、編集中の内容は削除されてしまいます。
+						選択中のメモを削除しますがよろしいでしょうか
 					</DialogContentText>
 				</DialogContent>
 				<DialogActions>
-					<Button onClick={handleClose}>保存</Button>
-					<Button
-						onClick={() => {
-							handleExitWithoutSavingClick();
-							handleClose();
-						}}
-					>
-						保存せずに編集終了
-					</Button>
+					<Button onClick={handleClose}>削除</Button>
 					<Button onClick={handleClose} autoFocus>
 						キャンセル
 					</Button>

--- a/src/components/augs/MainPage/MainLeftTop.tsx
+++ b/src/components/augs/MainPage/MainLeftTop.tsx
@@ -6,9 +6,8 @@ import { useRef } from "react";
 
 interface ContentTextBox1Props {
 	handleCreateButtonClick: () => void;
-	handleDeleteButtonClick: () => void;
 }
-export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButtonClick, handleDeleteButtonClick }) => {
+export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButtonClick }) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	if (inputRef.current) {
@@ -20,15 +19,6 @@ export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButton
 			<Button fullWidth style={{ justifyContent: "flex-start" }} onClick={handleCreateButtonClick}>
 				<AddIcon />
 				<Typography fontSize="12px">新規作成</Typography>
-			</Button>
-			<Button
-				fullWidth
-				items-align="flex-start"
-				style={{ justifyContent: "flex-start" }}
-				onClick={handleDeleteButtonClick}
-			>
-				<DeleteOutlineIcon />
-				<Typography fontSize="12px">削除</Typography>
 			</Button>
 		</Box>
 	);

--- a/src/components/augs/MainPage/MainLeftTop.tsx
+++ b/src/components/augs/MainPage/MainLeftTop.tsx
@@ -6,8 +6,9 @@ import { useRef } from "react";
 
 interface ContentTextBox1Props {
 	handleCreateButtonClick: () => void;
+	handleDeleteButtonClick: () => void;
 }
-export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButtonClick }) => {
+export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButtonClick, handleDeleteButtonClick }) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	if (inputRef.current) {
@@ -20,7 +21,12 @@ export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButton
 				<AddIcon />
 				<Typography fontSize="12px">新規作成</Typography>
 			</Button>
-			<Button fullWidth items-align="flex-start" style={{ justifyContent: "flex-start" }}>
+			<Button
+				fullWidth
+				items-align="flex-start"
+				style={{ justifyContent: "flex-start" }}
+				onClick={handleDeleteButtonClick}
+			>
 				<DeleteOutlineIcon />
 				<Typography fontSize="12px">削除</Typography>
 			</Button>

--- a/src/components/augs/MainPage/MainLeftTop.tsx
+++ b/src/components/augs/MainPage/MainLeftTop.tsx
@@ -1,16 +1,13 @@
-import { Box, Button, TextField, Typography } from "@mui/material";
+import { Box, Button, Typography } from "@mui/material";
 
 import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import { useEffect, useRef } from "react";
-import { apiClient } from "@/libs/apiClient";
-import { MemoContents } from "@/types";
-import { register } from "module";
+import { useRef } from "react";
 
 interface ContentTextBox1Props {
-	handleClick: () => void;
+	handleCreateButtonClick: () => void;
 }
-export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleClick }) => {
+export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleCreateButtonClick }) => {
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	if (inputRef.current) {
@@ -19,7 +16,7 @@ export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleClick }) => 
 
 	return (
 		<Box display="flex" alignItems="flex-start" flexDirection="column" gap={0.1}>
-			<Button fullWidth style={{ justifyContent: "flex-start" }} onClick={handleClick}>
+			<Button fullWidth style={{ justifyContent: "flex-start" }} onClick={handleCreateButtonClick}>
 				<AddIcon />
 				<Typography fontSize="12px">新規作成</Typography>
 			</Button>

--- a/src/components/augs/MainPage/MainLeftTop.tsx
+++ b/src/components/augs/MainPage/MainLeftTop.tsx
@@ -1,31 +1,25 @@
-import { Box, Button, Typography } from "@mui/material";
+import { Box, Button, TextField, Typography } from "@mui/material";
 
 import AddIcon from "@mui/icons-material/Add";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { apiClient } from "@/libs/apiClient";
 import { MemoContents } from "@/types";
+import { register } from "module";
 
-export const MainLeftTop = () => {
-	const onSubmit = (memoStatus: MemoContents) => {
-		console.log(memoStatus);
+interface ContentTextBox1Props {
+	handleClick: () => void;
+}
+export const MainLeftTop: React.FC<ContentTextBox1Props> = ({ handleClick }) => {
+	const inputRef = useRef<HTMLInputElement>(null);
 
-		useEffect(() => {
-			const putMemos = async () => {
-				try {
-					const response = await apiClient.put("/api/memos/{id}");
-					console.log(response.data);
-					// putMemos(response.data);
-				} catch (error) {
-					console.error("Error registering user:", error);
-				}
-			};
-			putMemos();
-		}, []);
-	};
+	if (inputRef.current) {
+		inputRef.current.focus();
+	}
+
 	return (
 		<Box display="flex" alignItems="flex-start" flexDirection="column" gap={0.1}>
-			<Button fullWidth style={{ justifyContent: "flex-start" }}>
+			<Button fullWidth style={{ justifyContent: "flex-start" }} onClick={handleClick}>
 				<AddIcon />
 				<Typography fontSize="12px">新規作成</Typography>
 			</Button>

--- a/src/components/augs/MainPage/MemoForm.tsx
+++ b/src/components/augs/MainPage/MemoForm.tsx
@@ -1,4 +1,5 @@
-import { Box, TextField } from "@mui/material";
+import { PostNemMemoFormBody } from "@/types";
+import { Box, Button, TextField } from "@mui/material";
 import { styled } from "@mui/system";
 import { forwardRef, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
@@ -9,42 +10,54 @@ const StyledTextField = styled(TextField, { name: "StyledTextField" })({
 type MemoFormProps = {
 	content?: string;
 	title?: string;
+	onSubmitPostNewMemo?: (date: PostNemMemoFormBody) => void;
 	// inputRef: React.Ref<HTMLInputElement>;
 	//?つけてオプショナルにする
 };
 
-export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(({ content, title }, inputRef) => {
-	const {
-		handleSubmit,
-		register,
-		setValue,
-		formState: { errors }
-	} = useForm({ defaultValues: { title, content } });
+export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
+	({ content, title, onSubmitPostNewMemo }, inputRef) => {
+		const {
+			handleSubmit,
+			register,
+			setValue,
+			formState: { errors }
+		} = useForm({ defaultValues: { title, content } });
 
-	const onSubmit = (data) => {};
+		const onSubmit = (data) => {};
 
-	useEffect(() => {
-		setValue("content", content);
-		setValue("title", title);
-		// if (inputRef.current) {
-		// 	inputRef.current.focus();
-		// }
-	}, [content, title]);
+		useEffect(() => {
+			setValue("content", content);
+			setValue("title", title);
+			// if (inputRef.current) {
+			// 	inputRef.current.focus();
+			// }
+		}, [content, title]);
 
-	return (
-		<Box display="flex" flexDirection="column" onSubmit={handleSubmit(onSubmit)}>
-			<TextField placeholder="タイトル" fullWidth {...register("title")} />
+		return (
+			<Box
+				component="form"
+				display="flex"
+				flexDirection="column"
+				onSubmit={handleSubmit((data) => {
+					console.log(data);
+					onSubmitPostNewMemo(data);
+				})}
+			>
+				<TextField placeholder="タイトル" fullWidth {...register("title")} />
 
-			<StyledTextField
-				placeholder="本文"
-				multiline
-				minRows="23"
-				maxRows="23"
-				fullWidth
-				inputRef={inputRef}
-				// ref={inputRef}
-				{...register("content")}
-			/>
-		</Box>
-	);
-});
+				<StyledTextField
+					placeholder="本文"
+					multiline
+					minRows="23"
+					maxRows="23"
+					fullWidth
+					inputRef={inputRef}
+					// ref={inputRef}
+					{...register("content")}
+				/>
+				<Button type="submit">保存</Button>
+			</Box>
+		);
+	}
+);

--- a/src/components/augs/MainPage/MemoForm.tsx
+++ b/src/components/augs/MainPage/MemoForm.tsx
@@ -25,14 +25,13 @@ export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
 			formState: { errors }
 		} = useForm({ defaultValues: { title, content } });
 
+		//ToDo:保存機能実装のときに使用
 		const onSubmit = (data) => {};
 
 		useEffect(() => {
 			setValue("content", content);
 			setValue("title", title);
 		}, [content, title]);
-		// console.log(content);
-		// console.log(watch("content"));
 
 		return (
 			<Box
@@ -52,9 +51,8 @@ export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
 					maxRows="23"
 					fullWidth
 					inputRef={inputRef}
-					// ref={inputRef}
 					{...register("content")}
-				/>{" "}
+				/>
 				<Fab variant="extended">
 					<NavigationIcon sx={{ mr: 1 }} />
 					Extended

--- a/src/components/augs/MainPage/MemoForm.tsx
+++ b/src/components/augs/MainPage/MemoForm.tsx
@@ -1,8 +1,9 @@
-import { PostNemMemoFormBody } from "@/types";
-import { Box, Button, TextField } from "@mui/material";
+import { PostNewMemoFormBody } from "@/types";
+import { Box, Button, Fab, TextField } from "@mui/material";
 import { styled } from "@mui/system";
 import { forwardRef, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
+import NavigationIcon from "@mui/icons-material/Add";
 
 const StyledTextField = styled(TextField, { name: "StyledTextField" })({
 	"& .MuiInputBase": { height: 550 }
@@ -10,8 +11,7 @@ const StyledTextField = styled(TextField, { name: "StyledTextField" })({
 type MemoFormProps = {
 	content?: string;
 	title?: string;
-	onSubmitPostNewMemo?: (date: PostNemMemoFormBody) => void;
-	// inputRef: React.Ref<HTMLInputElement>;
+	onSubmitPostNewMemo?: (date: PostNewMemoFormBody) => void;
 	//?つけてオプショナルにする
 };
 
@@ -21,6 +21,7 @@ export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
 			handleSubmit,
 			register,
 			setValue,
+			watch,
 			formState: { errors }
 		} = useForm({ defaultValues: { title, content } });
 
@@ -29,10 +30,9 @@ export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
 		useEffect(() => {
 			setValue("content", content);
 			setValue("title", title);
-			// if (inputRef.current) {
-			// 	inputRef.current.focus();
-			// }
 		}, [content, title]);
+		// console.log(content);
+		// console.log(watch("content"));
 
 		return (
 			<Box
@@ -45,7 +45,6 @@ export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
 				})}
 			>
 				<TextField placeholder="タイトル" fullWidth {...register("title")} />
-
 				<StyledTextField
 					placeholder="本文"
 					multiline
@@ -55,8 +54,11 @@ export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(
 					inputRef={inputRef}
 					// ref={inputRef}
 					{...register("content")}
-				/>
-				<Button type="submit">保存</Button>
+				/>{" "}
+				<Fab variant="extended">
+					<NavigationIcon sx={{ mr: 1 }} />
+					Extended
+				</Fab>
 			</Box>
 		);
 	}

--- a/src/components/augs/MainPage/MemoForm.tsx
+++ b/src/components/augs/MainPage/MemoForm.tsx
@@ -1,6 +1,6 @@
 import { Box, TextField } from "@mui/material";
 import { styled } from "@mui/system";
-import { useEffect, useRef } from "react";
+import { forwardRef, useEffect, useRef } from "react";
 import { useForm } from "react-hook-form";
 
 const StyledTextField = styled(TextField, { name: "StyledTextField" })({
@@ -9,12 +9,11 @@ const StyledTextField = styled(TextField, { name: "StyledTextField" })({
 type MemoFormProps = {
 	content?: string;
 	title?: string;
+	// inputRef: React.Ref<HTMLInputElement>;
 	//?つけてオプショナルにする
 };
 
-export const MemoForm = ({ content, title }: MemoFormProps) => {
-	const inputRef = useRef(null);
-
+export const MemoForm = forwardRef<HTMLInputElement, MemoFormProps>(({ content, title }, inputRef) => {
 	const {
 		handleSubmit,
 		register,
@@ -27,15 +26,15 @@ export const MemoForm = ({ content, title }: MemoFormProps) => {
 	useEffect(() => {
 		setValue("content", content);
 		setValue("title", title);
-		if (inputRef.current) {
-			inputRef.current.focus();
-		}
-		console.log(inputRef);
+		// if (inputRef.current) {
+		// 	inputRef.current.focus();
+		// }
 	}, [content, title]);
 
 	return (
 		<Box display="flex" flexDirection="column" onSubmit={handleSubmit(onSubmit)}>
 			<TextField placeholder="タイトル" fullWidth {...register("title")} />
+
 			<StyledTextField
 				placeholder="本文"
 				multiline
@@ -43,8 +42,9 @@ export const MemoForm = ({ content, title }: MemoFormProps) => {
 				maxRows="23"
 				fullWidth
 				inputRef={inputRef}
+				// ref={inputRef}
 				{...register("content")}
 			/>
 		</Box>
 	);
-};
+});

--- a/src/components/augs/MainPage/index.tsx
+++ b/src/components/augs/MainPage/index.tsx
@@ -16,7 +16,7 @@ export default function main() {
 
 	const [open, setOpen] = React.useState(false);
 
-	// daialog
+	// dialog
 	const handleClickOpen = () => {
 		setOpen(true);
 	};
@@ -43,6 +43,10 @@ export default function main() {
 		handleFocus();
 		// console.log(inputRef);
 	}, [selectedMemoIndex, getMemosData]);
+
+	const handleDeleteButtonClick = () => {
+		// 削除を書く
+	};
 
 	const handleCreateButtonClick = () => {
 		setNewMemoCreate(true);
@@ -76,7 +80,9 @@ export default function main() {
 
 	return (
 		<Grid container spacing={0.5} marginTop={8}>
+			{/* 新規メモを保存せずに他のメモへ移動しようとした場合のアラート（他ボタンへは未対応） */}
 			<AlertDialog open={open} handleClose={handleClose} handleExitWithoutSavingClick={handleExitWithoutSavingClick} />
+
 			{/* 左のフレーム */}
 			<Grid item xs={3.5}>
 				<Grid>
@@ -87,7 +93,10 @@ export default function main() {
 							backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#1A2027" : "#fff")
 						}}
 					>
-						<MainLeftTop handleCreateButtonClick={handleCreateButtonClick} />
+						<MainLeftTop
+							handleCreateButtonClick={handleCreateButtonClick}
+							handleDeleteButtonClick={handleDeleteButtonClick}
+						/>
 					</Paper>
 				</Grid>
 				<Grid>

--- a/src/components/augs/MainPage/index.tsx
+++ b/src/components/augs/MainPage/index.tsx
@@ -43,7 +43,6 @@ export default function main() {
 
 	useEffect(() => {
 		handleFocus();
-		// console.log(inputRef);
 	}, [selectedMemoIndex, getMemosData]);
 
 	// ゴミ捨てダイアログの挙動
@@ -53,7 +52,6 @@ export default function main() {
 	const [selectedDeleteIndex, setSelectedDeleteIndex] = useState<number | null>(null);
 	const handleTrashMemoDialogOpenClick = (index: number, id: number) => {
 		setDeleteDialogOpen(true);
-		console.log("deleteDialog");
 		setSelectedDeleteIndex(index);
 		setSelectedTrashMemoId(id);
 	};
@@ -87,21 +85,16 @@ export default function main() {
 		setNewMemoCreate(false);
 	};
 
-	// useEffect(() => {}, []);
 	const handlePrevMemoListClick = () => {
 		if (newMemoCreate) {
 			handleClickOpen();
 		}
-		// setNewMemoCreate(false) 後で移動させる
 	};
 
 	useEffect(() => {
 		if (!newMemoCreate) {
-			// console.log("click");
 		}
 	}, [newMemoCreate]);
-
-	// const onSubmitEditMemo = () => {};
 
 	const { mutationPostNewMemo } = usePostNewMemoApi();
 	const onSubmitPostNewMemo = (postBody: PostNewMemoFormBody) => {
@@ -209,7 +202,6 @@ export default function main() {
 				<Grid>
 					<Paper
 						sx={{
-							// height: "auto",
 							minHeight: "580px",
 							marginTop: "8px",
 							backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#1A2027" : "#fff")

--- a/src/components/augs/MainPage/index.tsx
+++ b/src/components/augs/MainPage/index.tsx
@@ -4,20 +4,31 @@ import { MainLeftTop } from "@/components/augs/MainPage/MainLeftTop";
 import { MemoForm } from "@/components/augs/MainPage/MemoForm";
 import { MainLoadingList } from "@/components/augs/MainPage/MainLoadingList";
 import { TrashBoxButtom } from "@/components/core/TrashBoxButtom";
-import { useGetMemos } from "@/modules/apiHooks/hooks";
-import { MemoContents } from "@/types";
+import { useGetMemos, usePostNewMemoApi } from "@/modules/apiHooks/hooks";
+import { MemoContents, PostNemMemoFormBody } from "@/types";
 import { Box, Grid, List, ListItem, ListItemButton, ListItemText, Paper } from "@mui/material";
 import Link from "next/link";
-import React, { useEffect, useRef, useState } from "react";
+import React, { use, useEffect, useRef, useState } from "react";
+import { AlertDialog } from "./AlertDialog";
 
 export default function main() {
 	const { getMemosData, getMemosError, getMemosIsPending } = useGetMemos();
+
+	const [open, setOpen] = React.useState(false);
+
+	// daialog
+	const handleClickOpen = () => {
+		setOpen(true);
+	};
+
+	const handleClose = () => {
+		setOpen(false);
+	};
 
 	const [selectedMemoIndex, setSelectedMemoIndex] = useState(0);
 
 	// 編集中であることを管理するステートを追加
 
-	// ①新しいメモを作成した状態を管理するステートをここに追加。true,falseの判定
 	const [newMemoCreate, setNewMemoCreate] = useState(false);
 
 	const inputRef = useRef<HTMLInputElement>(null);
@@ -38,8 +49,34 @@ export default function main() {
 		handleFocus();
 	};
 
+	const handleExitWithoutSavingClick = () => {
+		setNewMemoCreate(false);
+	};
+
+	// useEffect(() => {}, []);
+	const handlePrevMemoListClick = () => {
+		if (newMemoCreate) {
+			handleClickOpen();
+		}
+		// setNewMemoCreate(false) 後で移動させる
+	};
+
+	useEffect(() => {
+		if (!newMemoCreate) {
+			// console.log("click");
+		}
+	}, [newMemoCreate]);
+
+	// const onSubmitEditMemo = () => {};
+
+	const { mutationPostNewMemo } = usePostNewMemoApi();
+	const onSubmitPostNewMemo = (postBody: PostNemMemoFormBody) => {
+		mutationPostNewMemo.mutate(postBody);
+	};
+
 	return (
 		<Grid container spacing={0.5} marginTop={8}>
+			<AlertDialog open={open} handleClose={handleClose} handleExitWithoutSavingClick={handleExitWithoutSavingClick} />
 			{/* 左のフレーム */}
 			<Grid item xs={3.5}>
 				<Grid>
@@ -69,7 +106,7 @@ export default function main() {
 							<List>
 								{newMemoCreate && (
 									<ListItem disablePadding>
-										<ListItemButton>
+										<ListItemButton selected={newMemoCreate}>
 											<ListItemText primary={"新しいメモ"} />
 										</ListItemButton>
 									</ListItem>
@@ -78,8 +115,11 @@ export default function main() {
 									return (
 										<ListItem key={memo.id} disablePadding>
 											<ListItemButton
-												onClick={() => setSelectedMemoIndex(index)}
-												selected={selectedMemoIndex === index}
+												onClick={() => {
+													handlePrevMemoListClick(); //ダイアログで注意→このファルスをまとめた関数を作ってここにいれる
+													setSelectedMemoIndex(index);
+												}}
+												selected={selectedMemoIndex === index && !newMemoCreate}
 											>
 												<ListItemText primary={memo.title} />
 											</ListItemButton>
@@ -99,7 +139,9 @@ export default function main() {
 						}}
 					>
 						<Link href="/trashBox">
-							<TrashBoxButtom />
+							<TrashBoxButtom
+							// メモ編集中に移動しようとしたときにダイアログでるようにする
+							/>
 						</Link>
 					</Paper>
 				</Grid>
@@ -115,18 +157,15 @@ export default function main() {
 							backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#1A2027" : "#fff")
 						}}
 					>
-						{/* <Box sx={{ Height: "100%" }}> */}
 						{getMemosIsPending || !getMemosData ? undefined : (
 							<MemoForm
-								content={getMemosData[selectedMemoIndex].content}
-								title={getMemosData[selectedMemoIndex].title}
+								content={!newMemoCreate ? getMemosData[selectedMemoIndex].content : ""}
+								title={!newMemoCreate ? getMemosData[selectedMemoIndex].title : ""}
 								ref={inputRef}
+								onSubmitPostNewMemo={onSubmitPostNewMemo}
 							/>
-							// <Typography>{getMemosData[selectedMemoIndex].content}</Typography>
 						)}
-						{/* </Box> */}
 					</Paper>
-					{/* </Grid> */}
 				</Grid>
 			</Grid>
 		</Grid>

--- a/src/components/augs/MainPage/index.tsx
+++ b/src/components/augs/MainPage/index.tsx
@@ -8,18 +8,25 @@ import { useGetMemos } from "@/modules/apiHooks/hooks";
 import { MemoContents } from "@/types";
 import { Box, Grid, List, ListItem, ListItemButton, ListItemText, Paper } from "@mui/material";
 import Link from "next/link";
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 export default function main() {
 	const { getMemosData, getMemosError, getMemosIsPending } = useGetMemos();
 	// console.log(getMemosData);
-
 	const [selectedMemoIndex, setSelectedMemoIndex] = useState(0);
-
-	// const handleChange = (event: React.MouseEvent<HTMLElement>, newAlignment: string
-	// ) => {
-	// 	setSelectedMemoIndex(selectedMemoIndex);
-	// };
+	const inputRef = useRef<HTMLInputElement>(null);
+	const handleClick = () => {
+		if (inputRef.current) {
+			inputRef.current.focus();
+		}
+	};
+	useEffect(() => {
+		// if (inputRef.current) {
+		// 	inputRef.current.focus();
+		// }
+		handleClick();
+		console.log(inputRef);
+	}, [selectedMemoIndex, getMemosData]);
 
 	return (
 		<Grid container spacing={0.5} marginTop={8}>
@@ -33,7 +40,7 @@ export default function main() {
 							backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#1A2027" : "#fff")
 						}}
 					>
-						<MainLeftTop />
+						<MainLeftTop handleClick={handleClick} />
 					</Paper>
 				</Grid>
 				<Grid>
@@ -96,6 +103,7 @@ export default function main() {
 							<MemoForm
 								content={getMemosData[selectedMemoIndex].content}
 								title={getMemosData[selectedMemoIndex].title}
+								ref={inputRef}
 							/>
 							// <Typography>{getMemosData[selectedMemoIndex].content}</Typography>
 						)}

--- a/src/components/augs/MainPage/index.tsx
+++ b/src/components/augs/MainPage/index.tsx
@@ -12,21 +12,31 @@ import React, { useEffect, useRef, useState } from "react";
 
 export default function main() {
 	const { getMemosData, getMemosError, getMemosIsPending } = useGetMemos();
-	// console.log(getMemosData);
+
 	const [selectedMemoIndex, setSelectedMemoIndex] = useState(0);
+
+	// 編集中であることを管理するステートを追加
+
+	// ①新しいメモを作成した状態を管理するステートをここに追加。true,falseの判定
+	const [newMemoCreate, setNewMemoCreate] = useState(false);
+
 	const inputRef = useRef<HTMLInputElement>(null);
-	const handleClick = () => {
+
+	const handleFocus = () => {
 		if (inputRef.current) {
 			inputRef.current.focus();
 		}
 	};
+
 	useEffect(() => {
-		// if (inputRef.current) {
-		// 	inputRef.current.focus();
-		// }
-		handleClick();
-		console.log(inputRef);
+		handleFocus();
+		// console.log(inputRef);
 	}, [selectedMemoIndex, getMemosData]);
+
+	const handleCreateButtonClick = () => {
+		setNewMemoCreate(true);
+		handleFocus();
+	};
 
 	return (
 		<Grid container spacing={0.5} marginTop={8}>
@@ -40,7 +50,7 @@ export default function main() {
 							backgroundColor: (theme) => (theme.palette.mode === "dark" ? "#1A2027" : "#fff")
 						}}
 					>
-						<MainLeftTop handleClick={handleClick} />
+						<MainLeftTop handleCreateButtonClick={handleCreateButtonClick} />
 					</Paper>
 				</Grid>
 				<Grid>
@@ -57,6 +67,13 @@ export default function main() {
 							}}
 						>
 							<List>
+								{newMemoCreate && (
+									<ListItem disablePadding>
+										<ListItemButton>
+											<ListItemText primary={"新しいメモ"} />
+										</ListItemButton>
+									</ListItem>
+								)}
 								{getMemosData.map((memo: MemoContents, index: number) => {
 									return (
 										<ListItem key={memo.id} disablePadding>

--- a/src/components/core/DrawerMenuIcon/index.tsx
+++ b/src/components/core/DrawerMenuIcon/index.tsx
@@ -27,7 +27,7 @@ const DrawerMenuIcon: React.FC = () => {
 		right: false
 	});
 
-	const drawerMenuItems = ["ログイン・ログアウト", "", "", ""];
+	const drawerMenuItems = ["ログイン・ログアウト"];
 
 	const toggleDrawer = (anchor: Anchor, open: boolean) => (event: React.KeyboardEvent | React.MouseEvent) => {
 		if (
@@ -53,7 +53,7 @@ const DrawerMenuIcon: React.FC = () => {
 			onKeyDown={toggleDrawer(anchor, false)}
 		>
 			<List>
-				{["閉じる", "メモ", "", ""].map((text, index) => (
+				{["閉じる", "メモ"].map((text, index) => (
 					<ListItem key={text} disablePadding>
 						<ListItemButton>
 							<ListItemIcon>{iconListMenu[index]}</ListItemIcon>
@@ -62,6 +62,7 @@ const DrawerMenuIcon: React.FC = () => {
 					</ListItem>
 				))}
 			</List>
+
 			<Divider />
 			<List>
 				{drawerMenuItems.map((text, index) => (

--- a/src/components/core/TrashBoxButtom/index.tsx
+++ b/src/components/core/TrashBoxButtom/index.tsx
@@ -1,5 +1,4 @@
 import { Box, Button, Typography } from "@mui/material";
-
 import RestoreFromTrashIcon from "@mui/icons-material/RestoreFromTrash";
 
 export const TrashBoxButtom = () => {

--- a/src/modules/apiHooks/hooks.tsx
+++ b/src/modules/apiHooks/hooks.tsx
@@ -1,11 +1,5 @@
 import { apiClient } from "@/libs/apiClient";
-import {
-	LoginFormBody,
-	MemoContents,
-	PostNewMemoFormBody,
-	TrashMemoMutationVariables,
-	TrashMemoRequest
-} from "@/types";
+import { LoginFormBody, PostNewMemoFormBody, TrashMemoMutationVariables } from "@/types";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -39,11 +33,12 @@ export const useGetMemos = () => {
 	};
 	//respons? レスポンスがオブジェクトじゃない場合、後ろの.dataがヌルやアンディファインドの場合、評価を止める
 	// ? ←オプショナルチェーニング
-	const { isPending, error, data } = useQuery({
+	const { isPending, error, data, refetch } = useQuery({
 		queryKey: ["getMemosApiData"],
 		queryFn: getMemos
 	});
-	return { getMemosData: data, getMemosError: error, getMemosIsPending: isPending };
+
+	return { getMemosData: data, getMemosError: error, getMemosIsPending: isPending, refetchMemosData: refetch };
 };
 
 //メモ本文取得API,`/api/memos/${id}/`の${id}/`は動的に変わる
@@ -82,20 +77,25 @@ export const usePostNewMemoApi = () => {
 
 //削除用のAPI
 //{ id, postData }: TrashMemoMutationVariables...mutationFnには引数が1つしか渡されない為、id と postData をオブジェクトにまとめた
-export const usePostTrashMemoRequestApi = () => {
-	const postTrashMemoRequestApi = async ({ id, postData }: TrashMemoMutationVariables) => {
-		const response = await apiClient.post(`/api/memos/${id}`, postData);
+export const usePutTrashMemoRequestApi = () => {
+	const putTrashMemoRequestApi = async ({ id, putDate }: TrashMemoMutationVariables) => {
+		const token = localStorage.getItem(`accessToken`); // トークンを取得
+		if (!token) {
+			throw new Error("認証トークンが見つかりません");
+		}
+		const response = await apiClient.put(`/api/memos/${id}/`, putDate);
+
 		return response;
 	};
 
 	const mutation = useMutation({
-		mutationFn: postTrashMemoRequestApi,
+		mutationFn: putTrashMemoRequestApi,
 		onSuccess: (response) => {
 			console.log("トラッシュの対象にしました", response);
 		},
 		onError: (error) => {
-			console.error("Error registering user:", error);
+			console.error("Error registering user失敗:", error);
 		}
 	});
-	return { mutationPostTrashMemo: mutation };
+	return { mutationPutTrashMemo: mutation };
 };

--- a/src/modules/apiHooks/hooks.tsx
+++ b/src/modules/apiHooks/hooks.tsx
@@ -1,5 +1,11 @@
 import { apiClient } from "@/libs/apiClient";
-import { LoginFormBody, MemoContents, PostNemMemoFormBody } from "@/types";
+import {
+	LoginFormBody,
+	MemoContents,
+	PostNewMemoFormBody,
+	TrashMemoMutationVariables,
+	TrashMemoRequest
+} from "@/types";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -57,13 +63,13 @@ export const useGetOneMemo = (id: number) => {
 
 //新規メモ保存用のAPI
 export const usePostNewMemoApi = () => {
-	const usePostNewMemoApi = async (postData: PostNemMemoFormBody) => {
+	const postNewMemoApi = async (postData: PostNewMemoFormBody) => {
 		const response = await apiClient.post("/api/memos/", postData);
 		return response;
 	};
 
 	const mutation = useMutation({
-		mutationFn: usePostNewMemoApi,
+		mutationFn: postNewMemoApi,
 		onSuccess: (response) => {
 			console.log("登録しました", response);
 		},
@@ -72,4 +78,24 @@ export const usePostNewMemoApi = () => {
 		}
 	});
 	return { mutationPostNewMemo: mutation };
+};
+
+//削除用のAPI
+//{ id, postData }: TrashMemoMutationVariables...mutationFnには引数が1つしか渡されない為、id と postData をオブジェクトにまとめた
+export const usePostTrashMemoRequestApi = () => {
+	const postTrashMemoRequestApi = async ({ id, postData }: TrashMemoMutationVariables) => {
+		const response = await apiClient.post(`/api/memos/${id}`, postData);
+		return response;
+	};
+
+	const mutation = useMutation({
+		mutationFn: postTrashMemoRequestApi,
+		onSuccess: (response) => {
+			console.log("トラッシュの対象にしました", response);
+		},
+		onError: (error) => {
+			console.error("Error registering user:", error);
+		}
+	});
+	return { mutationPostTrashMemo: mutation };
 };

--- a/src/modules/apiHooks/hooks.tsx
+++ b/src/modules/apiHooks/hooks.tsx
@@ -1,5 +1,5 @@
 import { apiClient } from "@/libs/apiClient";
-import { LoginFormBody, MemoContents } from "@/types";
+import { LoginFormBody, MemoContents, PostNemMemoFormBody } from "@/types";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -53,4 +53,23 @@ export const useGetOneMemo = (id: number) => {
 		queryFn: getOneMemo
 	});
 	return { getOneMemoData: data, getOneMemoError: error, getOneMemoIsPending: isPending };
+};
+
+//新規メモ保存用のAPI
+export const usePostNewMemoApi = () => {
+	const usePostNewMemoApi = async (postData: PostNemMemoFormBody) => {
+		const response = await apiClient.post("/api/memos/", postData);
+		return response;
+	};
+
+	const mutation = useMutation({
+		mutationFn: usePostNewMemoApi,
+		onSuccess: (response) => {
+			console.log("登録しました", response);
+		},
+		onError: (error) => {
+			console.error("Error registering user:", error);
+		}
+	});
+	return { mutationPostNewMemo: mutation };
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,16 +24,20 @@ export type PostNewMemoFormBody = {
 	complete_flag?: boolean;
 };
 
-export type TrashMemoRequest = {
-	complete_flag: true;
-};
+// export type TrashMemoRequest = {
+// 	complete_flag: true;
+// };
 
 // ゴミ箱に移動するためのリクエストデータとIDを含む型を定義
 export type TrashMemoMutationVariables = {
 	id: number;
-	postData: TrashMemoRequest;
+	putDate: {
+		title: string;
+		content: string;
+		complete_flag: true;
+	};
 };
 
-export type ReturnMemoRequest = {
-	complete_flag: false;
-};
+// export type ReturnMemoRequest = {
+// 	complete_flag: false;
+// };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export type MemoContents = {
 	title: string;
 	content: string;
 	id: number;
-	complete_flag: boolean;
+	complete_flag?: boolean;
 	created_at: string;
 };
 
@@ -17,3 +17,9 @@ export type MemoContents = {
 // 	complete_flag: true;
 // 	created_at: string;
 // };
+
+export type PostNemMemoFormBody = {
+	title: string;
+	content: string;
+	complete_flag?: boolean;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,8 +18,22 @@ export type MemoContents = {
 // 	created_at: string;
 // };
 
-export type PostNemMemoFormBody = {
+export type PostNewMemoFormBody = {
 	title: string;
 	content: string;
 	complete_flag?: boolean;
+};
+
+export type TrashMemoRequest = {
+	complete_flag: true;
+};
+
+// ゴミ箱に移動するためのリクエストデータとIDを含む型を定義
+export type TrashMemoMutationVariables = {
+	id: number;
+	postData: TrashMemoRequest;
+};
+
+export type ReturnMemoRequest = {
+	complete_flag: false;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,10 +24,6 @@ export type PostNewMemoFormBody = {
 	complete_flag?: boolean;
 };
 
-// export type TrashMemoRequest = {
-// 	complete_flag: true;
-// };
-
 // ゴミ箱に移動するためのリクエストデータとIDを含む型を定義
 export type TrashMemoMutationVariables = {
 	id: number;
@@ -38,6 +34,12 @@ export type TrashMemoMutationVariables = {
 	};
 };
 
-// export type ReturnMemoRequest = {
-// 	complete_flag: false;
-// };
+// ゴミ箱からメインに戻すためのリクエストデータとIDを含む型を定義
+export type ReturnMemoMutationVariables = {
+	id: number;
+	putDate: {
+		title: string;
+		content: string;
+		complete_flag: false;
+	};
+};


### PR DESCRIPTION
## Issue No.（対応するissue）

CLOSE #25
CLOSE #36
CLOSE #37

## Files Changedの概要（何をやったか）
- MainLeftTop.tsxからMemoForm.tsx内のコンポーネントへフォーカスするようにした
- 新規作成をクリックしたら新しいメモがリストに表示される。
- 同操作を行った際に本文とタイトルを空にする
- 新規メモ作成時から別のメモを選択した際にダイアログを表示させるようにした
- 保存せずに終了した場合、リストから新規のメモが消えるようにした
- 新規メモの保存ボタンを仮置き、サーバーへpostできるようにAPIの設定をした

2024,9,1追加

- メインページに機能追加。
- メモタイトル右横の削除ボタンに下記挙動追加。
　・ダイアログ表示
　　・削除確認。削除なら、complete_flagをtrueに変更
　　　・再レンダリングさせる

- リストをフィルタリングし、complete_flagのfalseのみを表示させるようにした。

## エビデンス（実装箇所のスクショや録画等）

## 残タスク（今回のissueで残した課題や、新たな課題）

- 編集時と新規作成時の状態管理の追加
- 編集時と新規作成時でメモフォームの挙動を分岐させる
- ダイアログの保存ボタンもAPIと結合させる

## その他（レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載））

次にゴミ箱ページを作成しcomplete_flagをfalseに戻せるようにする